### PR TITLE
Fix reference to LiteDRAM in README.md file

### DIFF
--- a/README
+++ b/README
@@ -40,7 +40,7 @@ Core:
 
 [> FPGA Proven
 ---------------
-LiteDRAM is already used in commercial and open-source designs:
+LiteJESD204B is already used in commercial and open-source designs:
 - ARTIQ: http://m-labs.hk/artiq/index.html
 - and others commercial designs...
 


### PR DESCRIPTION
I assume this was meant to be LiteJESD204B not LiteDRAM.